### PR TITLE
Fix repository link in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "accept-language"
 description = "Parse and compare Accept-Language header strings"
 readme = "README.md"
-repository = "https://github.com/mike-engel/accept-language"
+repository = "https://github.com/mike-engel/accept-language-rs"
 documentation = "https://docs.rs/accept-language"
 license = "MIT"
 keywords = ["accept-language", "i18n", "internationalization", "header", "parser"]


### PR DESCRIPTION
Following the old link results in 404.