### PR TITLE
Correctly parse the language code "zh-Hant".

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,15 +55,7 @@ impl Language {
         let tag_parts: Vec<&str> = tag.split(";").collect();
         let name = match tag_parts.len() {
             0 => String::from(""),
-            _ => {
-                let name_parts: Vec<&str> = tag_parts[0].split("-").collect();
-
-                match name_parts.len() {
-                    2 => (name_parts[0].to_owned() + "-" + name_parts[1].to_uppercase().as_str())
-                        .to_string(),
-                    _ => tag_parts[0].to_string(),
-                }
-            }
+            _ => tag_parts[0].to_string(),
         };
         let quality = match tag_parts.len() {
             1 => 1.0,
@@ -256,5 +248,10 @@ mod tests {
         let common_languages = intersection(MOCK_ACCEPT_LANGUAGE, vec!["fr", "en-GB"]);
 
         assert_eq!(common_languages.len(), 0)
+    }
+
+    #[test]
+    fn it_parses_traditional_chinese() {
+        assert_eq!(parse("zh-Hant"), vec!["zh-Hant"]);
     }
 }


### PR DESCRIPTION
According to ISO 639-1 (per https://www.w3schools.com/tags/ref_language_codes.asp), `zh-Hant` and `zh-Hans` are valid language codes for Traditional Chinese and Simplified Chinese, respectively. These are new codes that are explicitly used to separate the notion of "writing system" from the notion of "language in a country", since multiple Chinese languages/dialects share the same writing system and are written with the same characters.

The current `parse()` logic fails to parse `zh-Hant` because it insists in capitalizing the second half as a "country code," producing `zh-HANT`, which is invalid.

This patch removes the forced-capitalization logic and adds a test.

We use this library in https://gitlab.com/openpowerlifting/opl-data. Thanks for making it!