### PR TITLE
Correct category

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/mike-engel/accept-language-rs"
 documentation = "https://docs.rs/accept-language"
 license = "MIT"
 keywords = ["accept-language", "i18n", "internationalization", "header", "parser"]
-categories = ["parsing"]
+categories = ["parser-implementations"]
 version = "1.2.1"
 authors = ["Mike Engel <mike@mike-engel.com>", "Sean Stangl"]
 


### PR DESCRIPTION
The "parsing" category is for tools to make new parsers, not format-specific parsers.