### PR TITLE
Avoid never used call to create empty string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,10 +53,7 @@ impl PartialEq for Language {
 impl Language {
     fn new(tag: &str) -> Language {
         let tag_parts: Vec<&str> = tag.split(';').collect();
-        let name = match tag_parts.len() {
-            0 => String::from(""),
-            _ => tag_parts[0].to_string(),
-        };
+        let name = tag_parts[0].to_string();
         let quality = match tag_parts.len() {
             1 => 1.0,
             _ => Language::quality_with_default(tag_parts[1]),


### PR DESCRIPTION
As the function split() will create a vector with a length of at least 1 ([see second example here](https://doc.rust-lang.org/std/primitive.str.html#examples-27)), the case where length equals zero will never happen. I checked with the [compiler explorer](https://godbolt.org/) and this reduces function new() with 20 machine code instructions.