### PR TITLE
Report distinction between default and non-default languages

### DIFF
--- a/benches/intersection.rs
+++ b/benches/intersection.rs
@@ -7,7 +7,7 @@ mod benches {
     use super::accept_language::*;
     use test::Bencher;
 
-    static MOCK_ACCEPT_LANGUAGE: &str = "en-US, de;q=0.7, zh-Hant, jp;q=0.1";
+    static MOCK_ACCEPT_LANGUAGE: &str = "en-US, nl, fr; q=0.3, de;q=0.7, zh-Hant: q=0.01, jp;q=0.1";
     static AVIALABLE_LANGUAGES: &[&str] = &[
         "aa", "ab", "ae", "af", "ak", "am", "an", "ar", "as", "av", "ay", "az", "ba", "be", "bg",
         "bh", "bi", "bm", "bn", "bo", "br", "bs", "ca", "ce", "ch", "co", "cr", "cs", "cu", "cv",
@@ -26,6 +26,16 @@ mod benches {
     ];
 
     #[bench]
+    fn bench_parse(b: &mut Bencher) {
+        b.iter(|| parse(MOCK_ACCEPT_LANGUAGE));
+    }
+
+    #[bench]
+    fn bench_parse_with_quality(b: &mut Bencher) {
+        b.iter(|| parse_with_quality(MOCK_ACCEPT_LANGUAGE));
+    }
+
+    #[bench]
     fn bench_intersections(b: &mut Bencher) {
         b.iter(|| intersection(MOCK_ACCEPT_LANGUAGE, AVIALABLE_LANGUAGES));
     }
@@ -33,5 +43,15 @@ mod benches {
     #[bench]
     fn bench_intersections_ordered(b: &mut Bencher) {
         b.iter(|| intersection_ordered(MOCK_ACCEPT_LANGUAGE, AVIALABLE_LANGUAGES));
+    }
+
+    #[bench]
+    fn bench_intersections_with_quality(b: &mut Bencher) {
+        b.iter(|| intersection_with_quality(MOCK_ACCEPT_LANGUAGE, AVIALABLE_LANGUAGES));
+    }
+
+    #[bench]
+    fn bench_intersections_ordered_with_quality(b: &mut Bencher) {
+        b.iter(|| intersection_ordered_with_quality(MOCK_ACCEPT_LANGUAGE, AVIALABLE_LANGUAGES));
     }
 }

--- a/benches/intersection.rs
+++ b/benches/intersection.rs
@@ -1,0 +1,37 @@
+#![feature(test)]
+extern crate accept_language;
+extern crate test;
+
+#[cfg(test)]
+mod benches {
+    use super::accept_language::*;
+    use test::Bencher;
+
+    static MOCK_ACCEPT_LANGUAGE: &str = "en-US, de;q=0.7, zh-Hant, jp;q=0.1";
+    static AVIALABLE_LANGUAGES: &[&str] = &[
+        "aa", "ab", "ae", "af", "ak", "am", "an", "ar", "as", "av", "ay", "az", "ba", "be", "bg",
+        "bh", "bi", "bm", "bn", "bo", "br", "bs", "ca", "ce", "ch", "co", "cr", "cs", "cu", "cv",
+        "cy", "da", "de", "dv", "dz", "ee", "el", "en", "en-UK", "en-US", "eo", "es", "es-ar",
+        "et", "eu", "fa", "ff", "fi", "fj", "fo", "fr", "fy", "ga", "gd", "gl", "gn", "gu", "gv",
+        "gv", "ha", "he", "hi", "ho", "hr", "ht", "hu", "hy", "hz", "ia", "id", "ie", "ig", "ii",
+        "ii", "ik", "in", "io", "is", "it", "iu", "ja", "jp", "jv", "ka", "kg", "ki", "kj", "kk",
+        "kl", "kl", "km", "kn", "ko", "kr", "ks", "ku", "kv", "kw", "ky", "la", "lb", "lg", "li",
+        "ln", "lo", "lt", "lu", "lv", "mg", "mh", "mi", "mk", "ml", "mn", "mo", "mr", "ms", "mt",
+        "my", "na", "nb", "nd", "ne", "ng", "nl", "nn", "no", "nr", "nv", "ny", "oc", "oj", "om",
+        "or", "os", "pa", "pi", "pl", "ps", "pt", "qu", "rm", "rn", "ro", "ru", "rw", "sa", "sd",
+        "se", "sg", "sh", "si", "sk", "sl", "sm", "sn", "so", "sq", "sr", "ss", "ss", "st", "su",
+        "sv", "sw", "ta", "te", "tg", "th", "ti", "tk", "tl", "tn", "to", "tr", "ts", "tt", "tw",
+        "ty", "ug", "uk", "ur", "uz", "ve", "vi", "vo", "wa", "wo", "xh", "yi", "yo", "za", "zh",
+        "zh-Hans", "zh-Hant", "zu",
+    ];
+
+    #[bench]
+    fn bench_intersections(b: &mut Bencher) {
+        b.iter(|| intersection(MOCK_ACCEPT_LANGUAGE, AVIALABLE_LANGUAGES));
+    }
+
+    #[bench]
+    fn bench_intersections_ordered(b: &mut Bencher) {
+        b.iter(|| intersection_ordered(MOCK_ACCEPT_LANGUAGE, AVIALABLE_LANGUAGES));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,18 +94,18 @@ pub fn parse(raw_languages: &str) -> Vec<String> {
 }
 
 /// Similar to [`parse`](parse) but with quality `f32` appended to notice if it is a default value.
-/// is used by [`intersection_with_qualification`](intersection_with_qualification) and
-/// [`intersection_ordered_with_qualification`](intersection_ordered_with_qualification).
+/// is used by [`intersection_with_quality`](intersection_with_quality) and
+/// [`intersection_ordered_with_quality`](intersection_ordered_with_quality).
 ///
 /// # Example
 ///
 /// ```
-/// use accept_language::parse_with_qualification;
+/// use accept_language::parse_with_quality;
 ///
-/// let user_languages = parse_with_qualification("en-US, en-GB;q=0.5");
+/// let user_languages = parse_with_quality("en-US, en-GB;q=0.5");
 /// assert_eq!(user_languages,vec![(String::from("en-US"), 1.0), (String::from("en-GB"), 0.5)])
 /// ```
-pub fn parse_with_qualification(raw_languages: &str) -> Vec<(String, f32)> {
+pub fn parse_with_quality(raw_languages: &str) -> Vec<(String, f32)> {
     let stripped_languages = raw_languages.to_owned().replace(' ', "");
     let language_strings: Vec<&str> = stripped_languages.split(',').collect();
     let mut languages: Vec<Language> = language_strings.iter().map(|l| Language::new(l)).collect();
@@ -113,6 +113,7 @@ pub fn parse_with_qualification(raw_languages: &str) -> Vec<(String, f32)> {
     languages
         .iter()
         .map(|l| (l.name.to_owned(), l.quality))
+        .filter(|l| !l.0.is_empty())
         .collect()
 }
 
@@ -159,39 +160,39 @@ pub fn intersection_ordered(raw_languages: &str, supported_languages: &[&str]) -
 /// # Example
 ///
 /// ```
-/// use accept_language::intersection_with_qualification;
+/// use accept_language::intersection_with_quality;
 ///
-/// let common_languages = intersection_with_qualification("en-US, en-GB;q=0.5", &["en-US", "de", "en-GB"]);
+/// let common_languages = intersection_with_quality("en-US, en-GB;q=0.5", &["en-US", "de", "en-GB"]);
 /// assert_eq!(common_languages,vec![(String::from("en-US"), 1.0), (String::from("en-GB"), 0.5)])
 /// ```
-pub fn intersection_with_qualification(
+pub fn intersection_with_quality(
     raw_languages: &str,
     supported_languages: &[&str],
 ) -> Vec<(String, f32)> {
-    let user_languages = parse_with_qualification(raw_languages);
+    let user_languages = parse_with_quality(raw_languages);
     user_languages
         .into_iter()
         .filter(|l| supported_languages.contains(&l.0.as_str()))
         .collect()
 }
 
-/// Similar to [`intersection_with_qualification`](intersection_with_qualification). The supported languages MUST
+/// Similar to [`intersection_with_quality`](intersection_with_quality). The supported languages MUST
 /// be in alphabetical order, to find the common languages that could be presented to a user.
 /// Executes roughly 25% faster.
 ///
 /// # Example
 ///
 /// ```
-/// use accept_language::intersection_ordered_with_qualification;
+/// use accept_language::intersection_ordered_with_quality;
 ///
-/// let common_languages = intersection_ordered_with_qualification("en-US, en-GB;q=0.5", &["de", "en-GB", "en-US"]);
+/// let common_languages = intersection_ordered_with_quality("en-US, en-GB;q=0.5", &["de", "en-GB", "en-US"]);
 /// assert_eq!(common_languages,vec![(String::from("en-US"), 1.0), (String::from("en-GB"), 0.5)])
 /// ```
-pub fn intersection_ordered_with_qualification(
+pub fn intersection_ordered_with_quality(
     raw_languages: &str,
     supported_languages: &[&str],
 ) -> Vec<(String, f32)> {
-    let user_languages = parse_with_qualification(raw_languages);
+    let user_languages = parse_with_quality(raw_languages);
     user_languages
         .into_iter()
         .filter(|l| supported_languages.binary_search(&l.0.as_str()).is_ok())
@@ -201,8 +202,8 @@ pub fn intersection_ordered_with_qualification(
 #[cfg(test)]
 mod tests {
     use super::{
-        intersection, intersection_ordered, intersection_ordered_with_qualification,
-        intersection_with_qualification, parse, Language,
+        intersection, intersection_ordered, intersection_ordered_with_quality,
+        intersection_with_quality, parse, Language,
     };
 
     static MOCK_ACCEPT_LANGUAGE: &str = "en-US, de;q=0.7, zh-Hant, jp;q=0.1";
@@ -331,9 +332,9 @@ mod tests {
     }
 
     #[test]
-    fn it_returns_language_intersection_with_qualification() {
+    fn it_returns_language_intersection_with_quality() {
         let common_languages =
-            intersection_with_qualification(MOCK_ACCEPT_LANGUAGE, &["en-US", "jp"]);
+            intersection_with_quality(MOCK_ACCEPT_LANGUAGE, &["en-US", "jp"]);
         assert_eq!(
             common_languages,
             vec![(String::from("en-US"), 1.0), (String::from("jp"), 0.1)]
@@ -341,9 +342,9 @@ mod tests {
     }
 
     #[test]
-    fn it_returns_language_intersection_ordered_with_qualification() {
+    fn it_returns_language_intersection_ordered_with_quality() {
         let common_languages =
-            intersection_ordered_with_qualification(MOCK_ACCEPT_LANGUAGE, &["en-US", "jp"]);
+            intersection_ordered_with_quality(MOCK_ACCEPT_LANGUAGE, &["en-US", "jp"]);
         assert_eq!(
             common_languages,
             vec![(String::from("en-US"), 1.0), (String::from("jp"), 0.1)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,8 +333,7 @@ mod tests {
 
     #[test]
     fn it_returns_language_intersection_with_quality() {
-        let common_languages =
-            intersection_with_quality(MOCK_ACCEPT_LANGUAGE, &["en-US", "jp"]);
+        let common_languages = intersection_with_quality(MOCK_ACCEPT_LANGUAGE, &["en-US", "jp"]);
         assert_eq!(
             common_languages,
             vec![(String::from("en-US"), 1.0), (String::from("jp"), 0.1)]


### PR DESCRIPTION
For a webserver, where new translation languages may appear after the initial release, it will be handy not to stick users to their non-default best match. This implements the request at issue https://github.com/mike-engel/accept-language-rs/issues/9.